### PR TITLE
Hotfix to use ID instead of count when init recipes

### DIFF
--- a/modules/recipe.py
+++ b/modules/recipe.py
@@ -8,20 +8,12 @@ class Recipe:
             ID number of recipe when in a list.
         name (str):
             Name of the recipe.
-<<<<<<< HEAD
-=======
         diets (list[str]):
             Dietary labels/categories of the recipe.
->>>>>>> star/dev
         ingredients (list[str]):
             Ingredients used in the recipe.
         instructions (str):
             Instructions for how to make the recipe.
-<<<<<<< HEAD
-        diets (list[str]):
-            Dietary labels/categories of the recipe.
-=======
->>>>>>> star/dev
     """
 
     def __init__(

--- a/modules/recipelist.py
+++ b/modules/recipelist.py
@@ -33,7 +33,7 @@ class RecipeList:
                     self.recipes.append(
                         # FIXME: change un/commented code when done with data
                         Recipe(
-                            id = count,
+                            id = int(key),
                             # id = int(key),
                             name = value["title"],
                             ingredients = value["ingreds"],

--- a/modules/revent.py
+++ b/modules/revent.py
@@ -1,4 +1,5 @@
 '''Recipie module for subclassing and event handling'''
+from functools import singledispatch
 import sys
 import traceback
 import re
@@ -553,7 +554,7 @@ class MainWindowRecipie(Ui_MainWindow):
             self.write_favourites_to_file()
             self.display_favourites_list()
             self.status_bar_display('Added favourite')
-            self.timer.start(1500)
+            self.timer.singleShot(1500, self.timeout_status_bar_display)
 
     def get_list_recipe_text(self, name: str, id: int) -> str:
         '''Sets display text for favourites and search results'''


### PR DESCRIPTION
First file is fixing artifacts from a bad pull somewhere. Then just updated recipelist.py to use the id number of recipe instead of count when it's initializing so favourites feature references the right recipe.